### PR TITLE
Support Symfony >= 2.7 Config component - fix #10

### DIFF
--- a/src/Tacker/Loader/CacheLoader.php
+++ b/src/Tacker/Loader/CacheLoader.php
@@ -55,7 +55,7 @@ class CacheLoader extends \Symfony\Component\Config\Loader\Loader
         }
 
         if (!isset($parameters)) {
-            require $cache->getPath();
+            require method_exists($cache, 'getPath') ? $cache->getPath() : (string) $cache;
         }
 
         return $parameters;


### PR DESCRIPTION
As we discussed, a `0.6.2` release could be nice because Flint `1.x` will fail with Symfony Config >= 2.7.
